### PR TITLE
Add PHP 8.5 and Laravel 13 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
         stability: [prefer-lowest, prefer-stable]
         exclude:
           - php: 8.1

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/session": "^8.0|^9.0|^10.0|^11.0|^12.0"
+        "php": "^7.4|^8.0|^8.5",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/session": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.35|^9.13|^10.2"
+        "orchestra/testbench": "^8.35|^9.13|^10.2|^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Flash.php
+++ b/src/Flash.php
@@ -2,7 +2,7 @@
 
 namespace MasterRO\Flash;
 
-use Session;
+use Illuminate\Support\Facades\Session;
 
 class Flash
 {
@@ -74,32 +74,30 @@ class Flash
         return $this;
     }
 
-    public function success(string $message, ?bool $storeInMainSession = null, ?array $data = null)
+    public function success(string $message, ?bool $storeInMainSession = null, ?array $data = null): mixed
     {
         return $this->fill($message, 'success', $storeInMainSession, $data)->push();
     }
 
-    public function warning(string $message, ?bool $storeInMainSession = null, ?array $data = null)
+    public function warning(string $message, ?bool $storeInMainSession = null, ?array $data = null): mixed
     {
         return $this->fill($message, 'warning', $storeInMainSession, $data)->push();
     }
 
-    public function info(string $message, ?bool $storeInMainSession = null, ?array $data = null)
+    public function info(string $message, ?bool $storeInMainSession = null, ?array $data = null): mixed
     {
         return $this->fill($message, 'info', $storeInMainSession, $data)->push();
     }
 
-    public function error(string $message, ?bool $storeInMainSession = null, ?array $data = null)
+    public function error(string $message, ?bool $storeInMainSession = null, ?array $data = null): mixed
     {
         return $this->fill($message, 'error', $storeInMainSession, $data)->push();
     }
 
     /**
      * Push this Flash Message to Session
-     *
-     * @return mixed
      */
-    public function push()
+    public function push(): mixed
     {
         $type = $this->type;
         $message = $this->message;
@@ -112,7 +110,7 @@ class Flash
         return Session::flash('flash_messages', [compact('type', 'message', 'data')]);
     }
 
-    public function __call($method, $arguments = [])
+    public function __call($method, $arguments = []): void
     {
         $this->fill($arguments[0], $method)->push();
     }

--- a/src/FlashMessagesServiceProvider.php
+++ b/src/FlashMessagesServiceProvider.php
@@ -9,7 +9,7 @@ class FlashMessagesServiceProvider extends ServiceProvider
     /**
      * Publish resources
      */
-    public function boot()
+    public function boot(): void
     {
         $this->mergeConfigFrom(
             __DIR__ . '/config/flash-messages.php', 'flash-messages'


### PR DESCRIPTION
- Extend PHP constraint to include ^8.5
- Extend illuminate/support and illuminate/session to include ^13.0
- Add orchestra/testbench ^11.0 for Laravel 13 test support
- Replace bare `use Session;` alias with explicit `use Illuminate\Support\Facades\Session;`
- Add explicit return types (mixed/void) to Flash methods and ServiceProvider::boot()

https://claude.ai/code/session_01BM3xGTUDwKM3q2jKtExQ4E